### PR TITLE
fix: Fix to run new trt models

### DIFF
--- a/runtime.py
+++ b/runtime.py
@@ -139,7 +139,7 @@ class TRTWrapper(ModelWrapper):
             [cuda.memcpy_dtoh_async(out.cpu, out.gpu, self.stream) for out in self.outputs]
             self.stream.synchronize()
 
-        result = self.outputs[0].cpu if self.model.num_bindings == 1 else self.outputs[3].cpu
+        result = self.outputs[0].cpu
         result = result.reshape((-1, len(classes)+5))
         return result
 
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     # load class info(.yaml)
     with open(args.classes) as f:
         classes = yaml.safe_load(f)
-        classes = classes['names']
+        classes = classes['class_names']
 
     # load model 
     extension = os.path.splitext(args.model)[1]

--- a/runtime.py
+++ b/runtime.py
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     # load class info(.yaml)
     with open(args.classes) as f:
         classes = yaml.safe_load(f)
-        classes = classes['class_names']
+        classes = classes['names']
 
     # load model 
     extension = os.path.splitext(args.model)[1]


### PR DESCRIPTION
1. 142 line을 새로운 trt model 형식에 맞게 outputs[0].cpu를 받도록 수정하였습니다.
2. classes['names']는 private branch에 있던 구버전 코드이므로, classes['class_names']로 바꿔주었습니다.