### PR TITLE
NSE-249: Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository involves the source codes for inferring models in the form of th
 $ python3 runtime.py --model ${model_file_path} --image_folder ${img_folder} --classes ${yaml_file_path} --mode save
 ```
 
-Please refer to [getting_started.md](https://github.com/Nota-NetsPresso/NetsPresso-ModelSearch-Runtime/blob/main/getting_started.md) and [example](https://github.com/Nota-NetsPresso/NetsPresso-ModelSearch-Runtime/blob/main/examples/readme.md) for more details.
+Please refer to [getting_started.md](https://github.com/Nota-NetsPresso/NetsPresso-ModelSearch-Runtime/blob/main/getting_started.md)
 
 ## Result
 


### PR DESCRIPTION
## AS-IS
Runtime repo 의 Readme 문서 안의 링크 파일이 삭제되었으나, 링크는 살아 있음.

## TO-BE
Readme 문서의 링크 삭제함.